### PR TITLE
Move the site.pp to the top of the repo

### DIFF
--- a/strace/.kitchen.yml
+++ b/strace/.kitchen.yml
@@ -5,7 +5,7 @@ driver:
 provisioner:
   name: puppet_apply
   require_chef_for_busser: false
-  manifests_path: manifests
+  manifests_path: .
   modules_path: ../
 
 verifier:

--- a/strace/site.pp
+++ b/strace/site.pp
@@ -1,0 +1,1 @@
+include strace


### PR DESCRIPTION
Having the site.pp inside the actual module code in
manifests felt very wrong so I'm going to try it here instead